### PR TITLE
Added option for custom template w/ options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ grunt.loadNpmTasks('grunt-jasmine-runner');
   - helpers : Any helpers files to aid in testing, loaded next
   - specs : Spec files that contain your jasmine tests
   - timeout : The timeout where the tests are abandoned
+  - template : Path to a custom template.
   - server :
     - port : The port to start the server on, defaults to 8888
   - junit :
@@ -37,6 +38,7 @@ grunt.loadNpmTasks('grunt-jasmine-runner');
   specs : 'specs/**/*Spec.js',
   helpers : 'specs/helpers/*.js',
   timeout : 10000,
+  template : 'src/custom.tmpl',
   junit : {
     output : 'junit/'
   },

--- a/tasks/jasmine.js
+++ b/tasks/jasmine.js
@@ -24,6 +24,10 @@ var options, defaultOptions = {
   specs   : [],
   src     : [],
   helpers : [],
+  template: {
+    src: __dirname + '/../jasmine/SpecRunner.tmpl',
+    opts: {}
+  },
   phantomjs : {}
 };
 
@@ -120,15 +124,18 @@ module.exports = function(g){
     var styles = getRelativeFileList(jasmineCss);
     var scripts = getRelativeFileList(jasmineCore, options.src, options.helpers, options.specs, phantomHelper, reporters, jasmineHelper);
 
-    var specRunnerTemplate = __dirname + '/../jasmine/SpecRunner.tmpl';
+    var specRunnerTemplate = typeof options.template === 'string' ? {
+      src: options.template,
+      opts: {}
+    } : options.template;
 
     var source;
-    grunt.file.copy(specRunnerTemplate, path.join(dir,tmpRunner), {
+    grunt.file.copy(specRunnerTemplate.src, path.join(dir,tmpRunner), {
       process : function(src) {
-        source = grunt.util._.template(src, {
+        source = grunt.util._.template(src, grunt.util._.extend({
           scripts : scripts,
           css : styles
-        });
+        }, specRunnerTemplate.opts));
         return source
       }
     });

--- a/test/expected/customTemplate/_SpecRunner.html
+++ b/test/expected/customTemplate/_SpecRunner.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+	<head>
+		<title>foo</title>
+	</head>
+	<body>
+		
+			<link rel="stylesheet" type="text/css" href="/jasmine/lib/jasmine-core/jasmine.css">
+		
+
+		
+			<script type="text/javascript" src="/jasmine/lib/jasmine-core/jasmine.js"></script>
+		
+			<script type="text/javascript" src="/jasmine/lib/jasmine-core/jasmine-html.js"></script>
+		
+			<script type="text/javascript" src="/jasmine/lib/jasmine-core/example/src/Player.js"></script>
+		
+			<script type="text/javascript" src="/jasmine/lib/jasmine-core/example/src/Song.js"></script>
+		
+			<script type="text/javascript" src="/jasmine/lib/jasmine-core/example/spec/SpecHelper.js"></script>
+		
+			<script type="text/javascript" src="/jasmine/lib/jasmine-core/example/spec/PlayerSpec.js"></script>
+		
+			<script type="text/javascript" src="/tasks/jasmine/phantom-helper.js"></script>
+		
+			<script type="text/javascript" src="/tasks/jasmine/reporters/ConsoleReporter.js"></script>
+		
+			<script type="text/javascript" src="/tasks/jasmine/reporters/JUnitReporter.js"></script>
+		
+			<script type="text/javascript" src="/tasks/jasmine/jasmine-helper.js"></script>
+		
+	</body>
+</html>

--- a/test/fixtures/customTemplate/custom.tmpl
+++ b/test/fixtures/customTemplate/custom.tmpl
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+	<head>
+		<title><%= title %></title>
+	</head>
+	<body>
+		<% css.forEach(function(style){ %>
+			<link rel="stylesheet" type="text/css" href="<%= style %>">
+		<% }) %>
+
+		<% scripts.forEach(function(script){ %>
+			<script type="text/javascript" src="<%= script %>"></script>
+		<% }) %>
+	</body>
+</html>

--- a/test/jasmine-runner_test.js
+++ b/test/jasmine-runner_test.js
@@ -1,4 +1,5 @@
-var grunt = require('grunt');
+var grunt = require('grunt'),
+fs = require('fs');
 
 /*
   ======== A Handy Little Nodeunit Reference ========
@@ -52,6 +53,49 @@ exports['jasmine-runner'] = {
       test.equal(status.total, 8, 'Ran all specs from example');
       test.equal(status.passed, 8, 'Passed all specs from example');
       test.ok(!err, 'No error received');
+      test.done();
+    }
+
+    grunt.helper('jasmine-phantom-runner', config, cb);
+  },
+  'custom template': function(test) {
+    test.expect(5);
+    // tests here
+
+    var config = {
+      timeout: 10000,
+      src     : 'jasmine/lib/jasmine-core/example/src/**/*.js',
+      helpers : 'jasmine/lib/jasmine-core/example/**/*Helper.js',
+      specs   : ['jasmine/lib/jasmine-core/example/**/*Spec.js'], // array to test support
+      server  : {
+        port : 8888
+      },
+      template: {
+        src: 'test/fixtures/customTemplate/custom.tmpl',
+        opts: {
+          title: 'foo'
+        }
+      },
+      junit : {
+        output : 'junit'
+      },
+      phantomjs : {
+        'ignore-ssl-errors' : true,
+        'local-to-remote-url-access' : true,
+        'web-security' : false
+      }
+    };
+
+    function cb(err,status){
+      test.equal(status.specs, 5, 'Found total specs from example');
+      test.equal(status.total, 8, 'Ran all specs from example');
+      test.equal(status.passed, 8, 'Passed all specs from example');
+      test.ok(!err, 'No error received');
+
+      var actual = grunt.file.read('_SpecRunner.html'),
+      expected = grunt.file.read('test/expected/customTemplate/_SpecRunner.html');
+
+      test.equal(expected, actual, 'generated spec runner with custom template');
       test.done();
     }
 


### PR DESCRIPTION
We're using a script loader(StealJS) and use a custom template currently with our jasmine specs. Switching over to grunt this week and this module fits all of our api needs, except the ability to pass a custom template w/ options through.
