### PR TITLE
convert path separator to slash on windows.

### DIFF
--- a/tasks/lib/jasmine.js
+++ b/tasks/lib/jasmine.js
@@ -49,7 +49,7 @@ function getRelativeFileList(/* args... */) {
     files = files.concat(grunt.file.expandFiles(listItem));
   });
   files = grunt.util._(files).map(function(file){
-    return path.resolve(file).replace(base,'');
+    return path.resolve(file).replace(base,'').replace(/\\/g,'/');
   });
   return files;
 }


### PR DESCRIPTION
windows path separator is backslash, so test is failed.
