### PR TITLE
Support for AMD Specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ grunt.loadNpmTasks('grunt-jasmine-runner');
   - src : Your source files to test, loaded first
   - helpers : Any helpers files to aid in testing, loaded next
   - specs : Spec files that contain your jasmine tests
+  - amd: If true the spec files will be loaded via an AMD `require` call.
   - timeout : The timeout where the tests are abandoned
   - template : Path to a custom template.
   - server :
@@ -49,6 +50,27 @@ grunt.loadNpmTasks('grunt-jasmine-runner');
 'jasmine-server' : {
   browser : false
 }
+```
+
+## AMD Specs
+
+If the `amd` flag is set in the config specs will be loaded via an AMD `require` call.  This does not make an assumption about the AMD library being used, you must specify the path to that in the helpers option e.g.
+
+```javascript
+helpers: [
+  '/path/to/require.js',
+  '/path/to/requireConfig.js'
+],
+```
+
+Spec files should define the module(s) they are testing directly as the `src` config option will be ignored in this case e.g.
+
+```javascript
+define(['/src/myModule.js'], function(MyModule){
+  describe('MyModule', function(){
+    // etc...
+  });
+});
 ```
 
 ## PhantomJS

--- a/jasmine/SpecRunner.tmpl
+++ b/jasmine/SpecRunner.tmpl
@@ -15,6 +15,16 @@
     <% scripts.forEach(function(script){ %>
     <script type="text/javascript" src="<%= script %>"></script>
     <% }) %>
+
+    <% if (typeof specs !== 'undefined') { %>
+        <script type="text/javascript">
+        require([
+        <% specs.forEach(function(script, i){ %>
+            '<%= script %>' <% if (i !== specs.length-1){ %>,<% } %>
+        <% }) %>
+        ]);
+        </script>
+    <% } %>
 </head>
 
 <body>

--- a/tasks/lib/jasmine.js
+++ b/tasks/lib/jasmine.js
@@ -20,7 +20,13 @@ exports.buildSpecrunner = function(dir, options, reporters){
   var jasmineHelper = __dirname + '/../jasmine/jasmine-helper.js';
 
   var styles = getRelativeFileList(jasmineCss);
-  var scripts = getRelativeFileList(jasmineCore, options.src, options.helpers, options.specs, phantomHelper, reporters, jasmineHelper);
+
+  if (options.amd) {
+    var specs = getRelativeFileList(options.specs);
+    var scripts = getRelativeFileList(jasmineCore, options.helpers, phantomHelper, reporters, jasmineHelper);
+  } else {
+    var scripts = getRelativeFileList(jasmineCore, options.src, options.helpers, options.specs, phantomHelper, reporters, jasmineHelper);
+  }
 
   var specRunnerTemplate = typeof options.template === 'string' ? {
     src: options.template,
@@ -32,6 +38,7 @@ exports.buildSpecrunner = function(dir, options, reporters){
     process : function(src) {
       source = grunt.util._.template(src, grunt.util._.extend({
         scripts : scripts,
+        specs: specs,
         css : styles
       }, specRunnerTemplate.opts));
       return source;


### PR DESCRIPTION
NB. This is a duplicate of an [earlier pull request](https://github.com/jasmine-contrib/grunt-jasmine-runner/pull/9) in light of [this comment](http://floatleft.com/notebook/using-grunt-and-jasmine-with-amd#comment-680021779)

This adds support for AMD source and spec files by requireing the specs directly onto the page.

This does not make an assumption about the AMD library being used, which needs to be specified in the helpers config option.
