### PR TITLE
Remove phantom.exit() when a file does not load

### DIFF
--- a/tasks/lib/phantomjs/bootstrap.js
+++ b/tasks/lib/phantomjs/bootstrap.js
@@ -114,7 +114,6 @@
     } else {
       // File loading failure.
       sendMessage('fail.load', url);
-      phantom.exit();
     }
   };
   page.open(url);


### PR DESCRIPTION
We're having problems with grunt-jasmine-runner on our project because every once in a while a file doesn't load, and when this happens phantom exits.  This is exacerbated by the fact that the grunt process appears to hang.

I'm not sure why we are getting so many onLoadFinished events (dozens) during a typical run even though the app generally sends everything through one URL.  Perhaps there's a better fix, but removing this phantom.exit makes our tests run reliably.
